### PR TITLE
Feature 9: Do not show virtual keyboard on mouse clicks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
                 "ng-packagr": "17.1.0",
                 "pixelmatch": "5.3.0",
                 "pngjs": "7.0.0",
-                "systelab-components-wdio-test": "1.14.0",
+                "systelab-components-wdio-test": "1.15.0",
                 "systelab-wdio-builder": "14.0.0",
                 "ts-node": "10.9.2",
                 "typescript": "5.2.2",
@@ -19255,9 +19255,9 @@
             }
         },
         "node_modules/systelab-components-wdio-test": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/systelab-components-wdio-test/-/systelab-components-wdio-test-1.14.0.tgz",
-            "integrity": "sha512-Kg76v8vrCCf2VhXAbCyouJuP/I4HR1NzOVh7is5JS5Fo0lbBDp67HuB+/AmFo2yIpwSPFEQXg261yWz1bgcVFw==",
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/systelab-components-wdio-test/-/systelab-components-wdio-test-1.15.0.tgz",
+            "integrity": "sha512-QPVwoDmlmdj17K7Pk9vabS58TcZZv2UcnsEAqKEsof72yWOyduoJheO9i/ALCzkgUjsQnN6fHcng/gE9vxfWEQ==",
             "dev": true,
             "dependencies": {
                 "core-js": "3.19.2",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
         "ng-packagr": "17.1.0",
         "pixelmatch": "5.3.0",
         "pngjs": "7.0.0",
-        "systelab-components-wdio-test": "1.14.0",
+        "systelab-components-wdio-test": "1.15.0",
         "systelab-wdio-builder": "14.0.0",
         "ts-node": "10.9.2",
         "typescript": "5.2.2",

--- a/projects/showcase/src/app/app.component.html
+++ b/projects/showcase/src/app/app.component.html
@@ -26,6 +26,10 @@
         <input class="input" type="text" inputmode="numeric" placeholder="Show virtual keyboard icon" vkEnabled [vkConfig]="vkConfigIcon">
     </div>
 
+    <div id="show-on-mouse-click-field" class="input-container">
+        <input class="input" type="text" placeholder="Show on mouse click" vkEnabled [vkConfig]="vkConfigMouseClick">
+    </div>
+
     <div id="fixed-bottom-positioning-field" class="input-container">
         <input class="input" type="text" placeholder="Fixed bottom positioning" vkEnabled vkFixedBottom>
     </div>

--- a/projects/showcase/src/app/app.component.ts
+++ b/projects/showcase/src/app/app.component.ts
@@ -19,6 +19,10 @@ export class AppComponent implements OnInit {
         showIcon: true,
     }
 
+    public vkConfigMouseClick: SystelabVirtualKeyboardConfig = {
+        showOnMouseClick: true,
+    }
+
     ngOnInit() {
         if (!environment.animationsEnabled) {
             const body = document.getElementsByTagName('body')[0];

--- a/projects/showcase/src/app/app.module.ts
+++ b/projects/showcase/src/app/app.module.ts
@@ -1,11 +1,18 @@
 import { NgModule } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
-import { SystelabVirtualKeyboardModule } from 'systelab-virtual-keyboard';
+import { SystelabVirtualKeyboardConfig, SystelabVirtualKeyboardModule } from 'systelab-virtual-keyboard';
 import { AppComponent } from './app.component';
 import { BrowserModule } from '@angular/platform-browser';
 
+
+const virtualKeyboardConfig: SystelabVirtualKeyboardConfig = {}; // Use default configuration
+
 @NgModule({
-    imports: [BrowserModule, RouterOutlet, SystelabVirtualKeyboardModule],
+    imports: [
+        BrowserModule,
+        RouterOutlet,
+        SystelabVirtualKeyboardModule.forRoot(virtualKeyboardConfig),
+    ],
     declarations: [AppComponent],
     bootstrap: [AppComponent]
 })

--- a/projects/showcase/test/mapping/input-field.ts
+++ b/projects/showcase/test/mapping/input-field.ts
@@ -4,7 +4,7 @@ import { VirtualKeyboard } from './virtual-keyboard';
 
 export class InputField extends Widget {
     public async setFocus(): Promise<void> {
-        return this.getInputText().click();
+        return this.getInputText().tap();
     }
 
     public async clear(): Promise<void> {

--- a/projects/showcase/test/mapping/input-field.ts
+++ b/projects/showcase/test/mapping/input-field.ts
@@ -3,8 +3,12 @@ import { VirtualKeyboard } from './virtual-keyboard';
 
 
 export class InputField extends Widget {
-    public async setFocus(): Promise<void> {
+    public async tap(): Promise<void> {
         return this.getInputText().tap();
+    }
+
+    public async click(): Promise<void> {
+        return this.getInputText().click();
     }
 
     public async clear(): Promise<void> {

--- a/projects/showcase/test/mapping/input-field.ts
+++ b/projects/showcase/test/mapping/input-field.ts
@@ -14,7 +14,7 @@ export class InputField extends Widget {
     public async clear(): Promise<void> {
         const currentText = await this.getText();
         for (let i = 0; i < currentText.length; i++) {
-            await VirtualKeyboard.get().clickBackspace();
+            await VirtualKeyboard.get().tapOnBackspace();
         }
     }
 

--- a/projects/showcase/test/mapping/showcase-page.ts
+++ b/projects/showcase/test/mapping/showcase-page.ts
@@ -29,11 +29,15 @@ export class ShowcasePage extends BasePage {
       return new InputField(this.byId('show-virtual-keyboard-icon-field'));
     }
 
+    public getShowOnMouseClickField(): InputField {
+      return new InputField(this.byId('show-on-mouse-click-field'));
+    }
+
     public getFixedBottomPositioningField(): InputField {
       return new InputField(this.byId('fixed-bottom-positioning-field'));
     }
 
-    public async clickOnBackground(): Promise<void> {
-      await this.byCSS('h1').click();
+    public async tapOnBackground(): Promise<void> {
+      await this.byCSS('h1').tap();
     }
 }

--- a/projects/showcase/test/mapping/showcase-page.ts
+++ b/projects/showcase/test/mapping/showcase-page.ts
@@ -35,6 +35,5 @@ export class ShowcasePage extends BasePage {
 
     public async clickOnBackground(): Promise<void> {
       await this.byCSS('h1').click();
-      await this.byCSS('h1').click(); // TODO: Hack needed while implementation issue is fixed
     }
 }

--- a/projects/showcase/test/mapping/virtual-keyboard.ts
+++ b/projects/showcase/test/mapping/virtual-keyboard.ts
@@ -1,4 +1,5 @@
 import { BasePage, ElementArrayFinder, ElementFinder } from 'systelab-components-wdio-test';
+import { SystelabVirtualKeyboardButton } from 'systelab-virtual-keyboard';
 
 
 export class VirtualKeyboard extends BasePage {
@@ -43,27 +44,27 @@ export class VirtualKeyboard extends BasePage {
     }
 
     public async tapOnBackspace(): Promise<void> {
-        await this.tapOnKey('{bksp}');
+        await this.tapOnKey(SystelabVirtualKeyboardButton.Backspace);
     }
 
     public async tapOnTab(): Promise<void> {
-        await this.tapOnKey('{tab}');
+        await this.tapOnKey(SystelabVirtualKeyboardButton.Tab);
     }
 
     public async tapOnCapsLock(): Promise<void> {
-        await this.tapOnKey('{lock}');
+        await this.tapOnKey(SystelabVirtualKeyboardButton.Lock);
     }
 
     public async tapOnShift(): Promise<void> {
-        await this.tapOnKey('{shift}');
+        await this.tapOnKey(SystelabVirtualKeyboardButton.Shift);
     }
 
     public async tapOnEnter(): Promise<void> {
-        await this.tapOnKey('{enter}');
+        await this.tapOnKey(SystelabVirtualKeyboardButton.Enter);
     }
 
     public async tapOnSpace(): Promise<void> {
-        await this.tapOnKey('{space}');
+        await this.tapOnKey(SystelabVirtualKeyboardButton.Space);
     }
 
     public async tapOnKey(keyValue: string): Promise<void> {

--- a/projects/showcase/test/mapping/virtual-keyboard.ts
+++ b/projects/showcase/test/mapping/virtual-keyboard.ts
@@ -35,39 +35,39 @@ export class VirtualKeyboard extends BasePage {
         return keys;
     }
 
-    public async clickKeys(text: string): Promise<void> {
+    public async tapOnKeys(text: string): Promise<void> {
         const keys: string[] = text.split('');
         for (let i = 0; i < keys.length; i++) {
-            await this.clickKey(keys[i]);
+            await this.tapOnKey(keys[i]);
         }
     }
 
-    public async clickBackspace(): Promise<void> {
-        await this.clickKey('{bksp}');
+    public async tapOnBackspace(): Promise<void> {
+        await this.tapOnKey('{bksp}');
     }
 
-    public async clickTab(): Promise<void> {
-        await this.clickKey('{tab}');
+    public async tapOnTab(): Promise<void> {
+        await this.tapOnKey('{tab}');
     }
 
-    public async clickCapsLock(): Promise<void> {
-        await this.clickKey('{lock}');
+    public async tapOnCapsLock(): Promise<void> {
+        await this.tapOnKey('{lock}');
     }
 
-    public async clickShift(): Promise<void> {
-        await this.clickKey('{shift}');
+    public async tapOnShift(): Promise<void> {
+        await this.tapOnKey('{shift}');
     }
 
-    public async clickEnter(): Promise<void> {
-        await this.clickKey('{enter}');
+    public async tapOnEnter(): Promise<void> {
+        await this.tapOnKey('{enter}');
     }
 
-    public async clickSpace(): Promise<void> {
-        await this.clickKey('{space}');
+    public async tapOnSpace(): Promise<void> {
+        await this.tapOnKey('{space}');
     }
 
-    public async clickKey(keyValue: string): Promise<void> {
+    public async tapOnKey(keyValue: string): Promise<void> {
         const keySelector: ElementFinder = this.getElementFinder().byCSS(`[data-skbtn='${keyValue}']`);
-        await keySelector.click();
+        await keySelector.click(); // Hack as current implementation of WDIO tap is not working
     }
 }

--- a/projects/showcase/test/mapping/virtual-keyboard.ts
+++ b/projects/showcase/test/mapping/virtual-keyboard.ts
@@ -1,5 +1,5 @@
 import { BasePage, ElementArrayFinder, ElementFinder } from 'systelab-components-wdio-test';
-import { SystelabVirtualKeyboardButton } from '../../../systelab-virtual-keyboard/src/public-api';
+import { SystelabVirtualKeyboardButton } from '../../../systelab-virtual-keyboard/src/lib/constants';
 
 
 export class VirtualKeyboard extends BasePage {

--- a/projects/showcase/test/mapping/virtual-keyboard.ts
+++ b/projects/showcase/test/mapping/virtual-keyboard.ts
@@ -1,5 +1,5 @@
 import { BasePage, ElementArrayFinder, ElementFinder } from 'systelab-components-wdio-test';
-import { SystelabVirtualKeyboardButton } from 'systelab-virtual-keyboard';
+import { SystelabVirtualKeyboardButton } from '../../../systelab-virtual-keyboard/src/public-api';
 
 
 export class VirtualKeyboard extends BasePage {

--- a/projects/showcase/test/specs/alphanumeric-layout.spec.ts
+++ b/projects/showcase/test/specs/alphanumeric-layout.spec.ts
@@ -23,8 +23,8 @@ describe("AlphanumericLayout", () => {
         await LayoutExpectation.expectAlphanumericLowercaseLayout();
     });
 
-    it("Write 'abcdefghijklmnopqrstuvwxyz' by clicking on virtual keyboard keys", async () => {
-        await VirtualKeyboard.get().clickKeys('abcdefghijklmnopqrstuvwxyz');
+    it("Write 'abcdefghijklmnopqrstuvwxyz' by tapping on virtual keyboard keys", async () => {
+        await VirtualKeyboard.get().tapOnKeys('abcdefghijklmnopqrstuvwxyz');
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays 'abcdefghijklmnopqrstuvwxyz'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual('abcdefghijklmnopqrstuvwxyz');
@@ -32,80 +32,80 @@ describe("AlphanumericLayout", () => {
     });
 
     it("Press 3 times the backspace key on the virtual keyboard", async () => {
-        await VirtualKeyboard.get().clickBackspace();
-        await VirtualKeyboard.get().clickBackspace();
-        await VirtualKeyboard.get().clickBackspace();
+        await VirtualKeyboard.get().tapOnBackspace();
+        await VirtualKeyboard.get().tapOnBackspace();
+        await VirtualKeyboard.get().tapOnBackspace();
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays 'abcdefghijklmnopqrstuvw'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual('abcdefghijklmnopqrstuvw');
         });
     });
 
-    it("Append '1234567890' by clicking on virtual keyboard keys", async () => {
-        await VirtualKeyboard.get().clickKeys('1234567890');
+    it("Append '1234567890' by tapping on virtual keyboard keys", async () => {
+        await VirtualKeyboard.get().tapOnKeys('1234567890');
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays 'abcdefghijklmnopqrstuvw1234567890'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual('abcdefghijklmnopqrstuvw1234567890');
         });
     });
 
-    it("Clear input content and write some symbols by clicking on virtual keyboard keys", async () => {
+    it("Clear input content and write some symbols by tapping on virtual keyboard keys", async () => {
         await ShowcasePage.get().getAutoAlphanumericLayoutField().clear();
-        await VirtualKeyboard.get().clickKeys("`-=;,./");
+        await VirtualKeyboard.get().tapOnKeys("`-=;,./");
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays '`-=;,./'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual("`-=;,./");
         });
     });
 
-    it("Click on 'Caps Lock' virtual keyboard key to change layout to uppercase", async () => {
-        await VirtualKeyboard.get().clickCapsLock();
+    it("Tap on 'Caps Lock' virtual keyboard key to change layout to uppercase", async () => {
+        await VirtualKeyboard.get().tapOnCapsLock();
 
         await LayoutExpectation.expectAlphanumericUppercaseLayout();
     });
 
-    it("Clear input content and write 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' by clicking on virtual keyboard keys", async () => {
+    it("Clear input content and write 'ABCDEFGHIJKLMNOPQRSTUVWXYZ' by tapping on virtual keyboard keys", async () => {
         await ShowcasePage.get().getAutoAlphanumericLayoutField().clear();
-        await VirtualKeyboard.get().clickKeys('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+        await VirtualKeyboard.get().tapOnKeys('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
         });
     });
 
-    it("Clear again input content and write some other symbols by clicking on virtual keyboard keys", async () => {
+    it("Clear again input content and write some other symbols by tapping on virtual keyboard keys", async () => {
         await ShowcasePage.get().getAutoAlphanumericLayoutField().clear();
-        await VirtualKeyboard.get().clickKeys('!@#$%#^*()_+?|{}:"');
+        await VirtualKeyboard.get().tapOnKeys('!@#$%#^*()_+?|{}:"');
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays '!@#$%#^*()_+?|{}:\"'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual('!@#$%#^*()_+?|{}:"');
         });
     });
 
-    it("Click again on 'Caps Lock' to return to lowercase layout", async () => {
-        await VirtualKeyboard.get().clickCapsLock();
+    it("Tap again on 'Caps Lock' to return to lowercase layout", async () => {
+        await VirtualKeyboard.get().tapOnCapsLock();
 
         await LayoutExpectation.expectAlphanumericLowercaseLayout();
     });
 
-    it("Click on 'Shift' virtual keyboard key to change layout to uppercase for only once key", async () => {
-        await VirtualKeyboard.get().clickShift();
+    it("Tap on 'Shift' virtual keyboard key to change layout to uppercase for only once key", async () => {
+        await VirtualKeyboard.get().tapOnShift();
 
         await LayoutExpectation.expectAlphanumericUppercaseLayout();
     });
 
-    it("Click on 'S' virtual keyboard key and the lowercase layout is back", async() => {
-        await VirtualKeyboard.get().clickKey('S');
+    it("Tap on 'S' virtual keyboard key and the lowercase layout is back", async() => {
+        await VirtualKeyboard.get().tapOnKey('S');
 
         await LayoutExpectation.expectAlphanumericLowercaseLayout();
     })
 
-    it("Clear again input content and write some text with a space and a tab by clicking on virtual keyboard keys", async () => {
+    it("Clear again input content and write some text with a space and a tab by tapping on virtual keyboard keys", async () => {
         await ShowcasePage.get().getAutoAlphanumericLayoutField().clear();
-        await VirtualKeyboard.get().clickKeys('space');
-        await VirtualKeyboard.get().clickSpace();
-        await VirtualKeyboard.get().clickKeys('and');
-        await VirtualKeyboard.get().clickTab();
+        await VirtualKeyboard.get().tapOnKeys('space');
+        await VirtualKeyboard.get().tapOnSpace();
+        await VirtualKeyboard.get().tapOnKeys('and');
+        await VirtualKeyboard.get().tapOnTab();
 
         await ReportUtility.addExpectedResult("Alphanumeric input displays 'space and\ttab'", async() => {
             expect(await ShowcasePage.get().getAutoAlphanumericLayoutField().getText()).toEqual('space and');

--- a/projects/showcase/test/specs/alphanumeric-layout.spec.ts
+++ b/projects/showcase/test/specs/alphanumeric-layout.spec.ts
@@ -17,8 +17,8 @@ describe("AlphanumericLayout", () => {
         TestIdentification.captureEnvironment();
     });
 
-    it("Set focus on auto-configured alphanumeric layout input field", async () => {
-        await ShowcasePage.get().getAutoAlphanumericLayoutField().setFocus();
+    it("Tap on auto-configured alphanumeric layout input field", async () => {
+        await ShowcasePage.get().getAutoAlphanumericLayoutField().tap();
 
         await LayoutExpectation.expectAlphanumericLowercaseLayout();
     });
@@ -112,8 +112,8 @@ describe("AlphanumericLayout", () => {
         });
     });
 
-    it("Click on page background to hide virtual keyboard", async () => {
-        await ShowcasePage.get().clickOnBackground();
+    it("Tap on page background to hide virtual keyboard", async () => {
+        await ShowcasePage.get().tapOnBackground();
 
         await ReportUtility.addExpectedResult("Virtual keyboard is not displayed", async() => {
             expect(await VirtualKeyboard.get().isPresent()).toBeFalsy();

--- a/projects/showcase/test/specs/numeric-layout.spec.ts
+++ b/projects/showcase/test/specs/numeric-layout.spec.ts
@@ -16,8 +16,8 @@ describe("NumericLayout", () => {
         TestIdentification.captureEnvironment();
     });
 
-    it("Set focus on auto-configured numeric input field", async () => {
-        await ShowcasePage.get().getAutoNumericLayoutField().setFocus();
+    it("Tap on auto-configured numeric input field", async () => {
+        await ShowcasePage.get().getAutoNumericLayoutField().tap();
 
         await ReportUtility.addExpectedResult("Virtual keyboard is shown with 4 rows of keys including all numbers and backspace", async() => {
             expect(await VirtualKeyboard.get().isPresent()).toBeTruthy();
@@ -55,8 +55,8 @@ describe("NumericLayout", () => {
         });
     });
 
-    it("Click on page background to hide virtual keyboard", async () => {
-        await ShowcasePage.get().clickOnBackground();
+    it("Tap on page background to hide virtual keyboard", async () => {
+        await ShowcasePage.get().tapOnBackground();
 
         await ReportUtility.addExpectedResult("Virtual keyboard is not displayed", async() => {
             expect(await VirtualKeyboard.get().isPresent()).toBeFalsy();

--- a/projects/showcase/test/specs/numeric-layout.spec.ts
+++ b/projects/showcase/test/specs/numeric-layout.spec.ts
@@ -29,26 +29,26 @@ describe("NumericLayout", () => {
         });
     });
 
-    it("Write '9876543210' by clicking on virtual keyboard keys", async () => {
-        await VirtualKeyboard.get().clickKeys('9876543210');
+    it("Write '9876543210' by tapping on virtual keyboard keys", async () => {
+        await VirtualKeyboard.get().tapOnKeys('9876543210');
 
         await ReportUtility.addExpectedResult("Numeric input displays '9876543210'", async() => {
             expect(await ShowcasePage.get().getAutoNumericLayoutField().getText()).toEqual('9876543210');
         });
     });
 
-    it("Press 3 times the backspace key on the virtual keyboard", async () => {
-        await VirtualKeyboard.get().clickBackspace();
-        await VirtualKeyboard.get().clickBackspace();
-        await VirtualKeyboard.get().clickBackspace();
+    it("Tap 3 times the backspace key on the virtual keyboard", async () => {
+        await VirtualKeyboard.get().tapOnBackspace();
+        await VirtualKeyboard.get().tapOnBackspace();
+        await VirtualKeyboard.get().tapOnBackspace();
 
         await ReportUtility.addExpectedResult("Numeric input displays '9876543'", async() => {
             expect(await ShowcasePage.get().getAutoNumericLayoutField().getText()).toEqual('9876543');
         });
     });
 
-    it("Append '666' by clicking on virtual keyboard keys", async () => {
-        await VirtualKeyboard.get().clickKeys('666');
+    it("Append '666' by tapping on virtual keyboard keys", async () => {
+        await VirtualKeyboard.get().tapOnKeys('666');
 
         await ReportUtility.addExpectedResult("Numeric input displays '9876543666'", async() => {
             expect(await ShowcasePage.get().getAutoNumericLayoutField().getText()).toEqual('9876543666');

--- a/projects/showcase/test/specs/position-and-size.spec.ts
+++ b/projects/showcase/test/specs/position-and-size.spec.ts
@@ -59,8 +59,8 @@ describe("PositionAndSize", () => {
         });
     });
 
-    it("Press 'Tab' key on physical keyboard to change focus to input field with auto-configured numeric layout", async () => {
-        await Browser.pressTab();
+    it("Tap on auto-configured numeric layout input field", async () => {
+        await ShowcasePage.get().getAutoNumericLayoutField().setFocus();
 
         const keyboardRect = await VirtualKeyboard.get().getBoundingRect();
         const inputRect = await ShowcasePage.get().getAutoNumericLayoutField().getBoundingRect();

--- a/projects/showcase/test/specs/position-and-size.spec.ts
+++ b/projects/showcase/test/specs/position-and-size.spec.ts
@@ -33,8 +33,8 @@ describe("PositionAndSize", () => {
         });
     });
 
-    it("Open virtual keyboard on input field with auto-configured alphanumeric layout", async () => {
-        await ShowcasePage.get().getAutoAlphanumericLayoutField().setFocus();
+    it("Tap on input field with auto-configured alphanumeric layout", async () => {
+        await ShowcasePage.get().getAutoAlphanumericLayoutField().tap();
 
         const keyboardRect = await VirtualKeyboard.get().getBoundingRect();
         const inputRect = await ShowcasePage.get().getAutoAlphanumericLayoutField().getBoundingRect();
@@ -59,8 +59,9 @@ describe("PositionAndSize", () => {
         });
     });
 
-    it("Tap on auto-configured numeric layout input field", async () => {
-        await ShowcasePage.get().getAutoNumericLayoutField().setFocus();
+    it("Tap on background and tap on auto-configured numeric layout input field", async () => {
+        await ShowcasePage.get().tapOnBackground();
+        await ShowcasePage.get().getAutoNumericLayoutField().tap();
 
         const keyboardRect = await VirtualKeyboard.get().getBoundingRect();
         const inputRect = await ShowcasePage.get().getAutoNumericLayoutField().getBoundingRect();
@@ -85,9 +86,9 @@ describe("PositionAndSize", () => {
         });
     });
 
-    it("Change focus to input text with manually configured numeric layout", async () => {
-        await ShowcasePage.get().clickOnBackground();
-        await ShowcasePage.get().getManualNumericLayoutField().setFocus();
+    it("Tap on background and tap on input text with manually configured numeric layout", async () => {
+        await ShowcasePage.get().tapOnBackground();
+        await ShowcasePage.get().getManualNumericLayoutField().tap();
 
         const keyboardRect = await VirtualKeyboard.get().getBoundingRect();
         const inputRect = await ShowcasePage.get().getManualNumericLayoutField().getBoundingRect();
@@ -107,8 +108,8 @@ describe("PositionAndSize", () => {
         });
     });
 
-    it("Click on virtual keyboard icon of the only input field that has it", async () => {
-        await ShowcasePage.get().clickOnBackground();
+    it("Tap on background and click on virtual keyboard icon of the only input field that has it", async () => {
+        await ShowcasePage.get().tapOnBackground();
         await ShowcasePage.get().getShowVirtualKeyboardIconField().clickVirtualKeyboardIcon();
 
         await ReportUtility.addExpectedResult("Virtual keyboard continues being shown", async() => {
@@ -128,9 +129,33 @@ describe("PositionAndSize", () => {
         });
     });
 
+    it("Tap on background and do a mouse click on same input field", async () => {
+        await ShowcasePage.get().tapOnBackground();
+        await ShowcasePage.get().getShowVirtualKeyboardIconField().click();
+
+        await ReportUtility.addExpectedResult("Virtual keyboard is not shown anymore", async() => {
+            expect(await VirtualKeyboard.get().isPresent()).toBeFalsy();
+        });
+    });
+    
+    it("Do a mouse click on the only input field that accepts mouse clicks to show virtual keyboard", async () => {
+        await ShowcasePage.get().tapOnBackground();
+        await ShowcasePage.get().getShowOnMouseClickField().click();
+
+        await ReportUtility.addExpectedResult("Virtual keyboard is shown again", async() => {
+            expect(await VirtualKeyboard.get().isPresent()).toBeTruthy();
+        });
+
+        const inputRect = await ShowcasePage.get().getShowOnMouseClickField().getBoundingRect();
+        const keyboardRect = await VirtualKeyboard.get().getBoundingRect();
+        await ReportUtility.addExpectedResult("Virtual keyboard is located just under the input field that accepts clicks", async() => {
+            expect(keyboardRect.y).toBeLocatedAs(inputRect.y + inputRect.height);
+        });
+    });
+
     it("Change focus to input field configured virtual keyboard in fixed bottom position", async () => {
-        await ShowcasePage.get().clickOnBackground();
-        await ShowcasePage.get().getFixedBottomPositioningField().setFocus();
+        await ShowcasePage.get().tapOnBackground();
+        await ShowcasePage.get().getFixedBottomPositioningField().tap();
 
         await ReportUtility.addExpectedResult("Virtual keyboard continues being shown", async() => {
             expect(await VirtualKeyboard.get().isPresent()).toBeTruthy();

--- a/projects/showcase/test/specs/position-and-size.spec.ts
+++ b/projects/showcase/test/specs/position-and-size.spec.ts
@@ -108,7 +108,7 @@ describe("PositionAndSize", () => {
         });
     });
 
-    it("Tap on background and click on virtual keyboard icon of the only input field that has it", async () => {
+    it("Tap on background and then click on virtual keyboard icon of the only input field that has it", async () => {
         await ShowcasePage.get().tapOnBackground();
         await ShowcasePage.get().getShowVirtualKeyboardIconField().clickVirtualKeyboardIcon();
 

--- a/projects/systelab-virtual-keyboard/README.md
+++ b/projects/systelab-virtual-keyboard/README.md
@@ -42,4 +42,4 @@ The configuration params are describe into the interface [SystelabVirtualKeyboar
 | layout |  SystelabVirtualKeyboardLayouts | | Usually the virtual keyboard select the layout between *default* or *numeric* depending on the input type. But with the config object you can override this behaviour and force the desired layout. The available layouts are described in the enum *SystelabVirtualKeyboardLayouts*
 | inputMethod | SystelabVirtualKeyboardInputMethods | | The method detected for the keyboard to click or touch the keys
 | showButton | boolean | false | Show or hide the button for showing the keyboard
-
+| showOnMouseClick | boolean | false | Shows virtual keyboard upon mouse click on input field

--- a/projects/systelab-virtual-keyboard/package.json
+++ b/projects/systelab-virtual-keyboard/package.json
@@ -1,6 +1,6 @@
 {
     "name": "systelab-virtual-keyboard",
-    "version": "17.1.0",
+    "version": "17.2.0",
     "peerDependencies": {
         "@angular/common": "^17.0.0",
         "@angular/core": "^17.0.0",

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard-overlay.service.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard-overlay.service.ts
@@ -30,7 +30,7 @@ export class SystelabVirtualKeyboardOverlayService {
     private showKeyboardButtonElement: HTMLElement;
     private open: boolean;
     private layout: SystelabVirtualKeyboardLayouts;
-    private focusDispatched: boolean = false;
+    private clickAlreadyHandled: boolean = false;
 
     constructor(private readonly overlay: Overlay) {
         this.initListener();
@@ -75,8 +75,8 @@ export class SystelabVirtualKeyboardOverlayService {
         this.updatePositionStrategy(this.inputOrigin, this.fixedBottom);
     }
 
-    public setFocusDispatched(dispatched: boolean): void {
-        this.focusDispatched = dispatched;
+    public setClickAlreadyHandled(): void {
+        this.clickAlreadyHandled = true;
     }
 
     public destroy(): void {
@@ -92,26 +92,22 @@ export class SystelabVirtualKeyboardOverlayService {
     }
 
     private handleClick(event: MouseEvent) {
-        if (this.focusDispatched) {
-            this.focusDispatched = false;
+        if (this.clickAlreadyHandled) {
+            this.clickAlreadyHandled = false;
             return;
         }
-        console.log('Document clicked:', event);
-        event.stopPropagation();
-        const simpleKeyboardElement = document.querySelector('.simple-keyboard');
-        const showKeyboardButtonClicked = (event.target as HTMLElement)?.classList.contains('virtual-keyboard-show-button');
 
-        const containsKeyboard = simpleKeyboardElement?.contains(event.target as Node);
-        const containsElementRef = this.inputOrigin?.contains(event.target as Node);
-        // const containsFocusedElement = this.focusedElement?.contains(event.target as Node);
-        const containsShowButton = this.showKeyboardButtonElement?.contains(event.target as Node);
-        if (
-            !containsKeyboard &&
-      !containsElementRef &&
-      // !containsFocusedElement &&
-      !containsShowButton &&
-      !showKeyboardButtonClicked
-        ) {
+        event.stopPropagation();
+
+        const showKeyboardButtonClicked: boolean = (event.target as HTMLElement)?.classList.contains('virtual-keyboard-show-button');
+        const virtualKeyboardClicked: boolean = document.querySelector('.simple-keyboard')?.contains(event.target as Node);
+        const inputElementClicked: boolean = this.inputOrigin?.contains(event.target as Node);
+        const containsShowButton: boolean = this.showKeyboardButtonElement?.contains(event.target as Node);
+
+        if (!virtualKeyboardClicked &&
+            !inputElementClicked &&
+            !containsShowButton &&
+            !showKeyboardButtonClicked) {
             if (this.isCreated()) {
                 this.destroy();
             }
@@ -123,11 +119,15 @@ export class SystelabVirtualKeyboardOverlayService {
     }
 
     private updatePositionStrategy(inputOrigin: HTMLInputElement, fixedBottom: boolean): void {
-        this.overlayRef.updatePositionStrategy(this.getPositionStrategy(inputOrigin, fixedBottom));
+        if (!!this.overlayRef) {
+            this.overlayRef.updatePositionStrategy(this.getPositionStrategy(inputOrigin, fixedBottom));
+        }
     }
 
     private updateSize(): void {
-        this.overlayRef.updateSize(this.getOverlaySize());
+        if (!!this.overlayRef) {
+            this.overlayRef.updateSize(this.getOverlaySize());
+        }
     }
 
     private getPositionStrategy(inputOrigin: HTMLInputElement, fixedBottom: boolean): PositionStrategy {

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard-overlay.service.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard-overlay.service.ts
@@ -31,6 +31,7 @@ export class SystelabVirtualKeyboardOverlayService {
     private open: boolean;
     private layout: SystelabVirtualKeyboardLayouts;
     private clickAlreadyHandled: boolean = false;
+    private touchEndAlreadyHandled: boolean = false;
 
     constructor(private readonly overlay: Overlay) {
         this.initListener();
@@ -79,6 +80,10 @@ export class SystelabVirtualKeyboardOverlayService {
         this.clickAlreadyHandled = true;
     }
 
+    public setTouchEndAlreadyHandled(): void {
+        this.touchEndAlreadyHandled = true;
+    }
+
     public destroy(): void {
         if (this.overlayRef) {
             this.overlayRef.dispose();
@@ -89,6 +94,7 @@ export class SystelabVirtualKeyboardOverlayService {
 
     private initListener() {
         document.addEventListener('click', this.handleClick.bind(this));
+        document.addEventListener('touchend', this.handleTouchEnd.bind(this));
     }
 
     private handleClick(event: MouseEvent) {
@@ -98,16 +104,29 @@ export class SystelabVirtualKeyboardOverlayService {
         }
 
         event.stopPropagation();
+        this.handleEventTarget(event.target);
+    }
 
-        const showKeyboardButtonClicked: boolean = (event.target as HTMLElement)?.classList.contains('virtual-keyboard-show-button');
-        const virtualKeyboardClicked: boolean = document.querySelector('.simple-keyboard')?.contains(event.target as Node);
-        const inputElementClicked: boolean = this.inputOrigin?.contains(event.target as Node);
-        const containsShowButton: boolean = this.showKeyboardButtonElement?.contains(event.target as Node);
+    private handleTouchEnd(event: TouchEvent) {
+        if (this.touchEndAlreadyHandled) {
+            this.touchEndAlreadyHandled = false;
+            return;
+        }
 
-        if (!virtualKeyboardClicked &&
-            !inputElementClicked &&
+        event.stopPropagation();
+        this.handleEventTarget(event.target);
+    }
+
+    private handleEventTarget(target: EventTarget) {
+        const showKeyboardButtonTarget: boolean = (target as HTMLElement)?.classList.contains('virtual-keyboard-show-button');
+        const virtualKeyboardTarget: boolean = document.querySelector('.simple-keyboard')?.contains(target as Node);
+        const inputElementTarget: boolean = this.inputOrigin?.contains(target as Node);
+        const containsShowButton: boolean = this.showKeyboardButtonElement?.contains(target as Node);
+
+        if (!virtualKeyboardTarget &&
+            !inputElementTarget &&
             !containsShowButton &&
-            !showKeyboardButtonClicked) {
+            !showKeyboardButtonTarget) {
             if (this.isCreated()) {
                 this.destroy();
             }

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.config.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.config.ts
@@ -7,4 +7,5 @@ export interface SystelabVirtualKeyboardConfig {
     layout?: SystelabVirtualKeyboardLayouts;
     inputMethod?: SystelabVirtualKeyboardInputMethods;
     showIcon?: boolean;
+    showOnMouseClick?: boolean;
 }

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.directive.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.directive.ts
@@ -61,6 +61,7 @@ export class SystelabVirtualKeyboardDirective implements OnInit, AfterViewInit, 
         }
 
         this.closePanel();
+        this.overlayService.setTouchEndAlreadyHandled();
         this.openPanel();
     }
 

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.directive.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.directive.ts
@@ -40,23 +40,28 @@ export class SystelabVirtualKeyboardDirective implements OnInit, AfterViewInit, 
         if (!this.vkEnabled) {
             return;
         }
-        if (this.overlayService.isCreated()) {
-            this.overlayService.updatePosition();
-        }
+        this.overlayService.updatePosition();
     }
 
-    @HostListener('focus', ['$event'])
-    onFocus(): void {
+    @HostListener('click', ['$event'])
+    onClick(): void {
+        if (!this.vkEnabled || !this.config.showOnMouseClick) {
+            return;
+        }
+
+        this.closePanel();
+        this.overlayService.setClickAlreadyHandled();
+        this.openPanel();
+    }
+
+    @HostListener('touchend', ['$event'])
+    onTouchEnd(): void {
         if (!this.vkEnabled) {
             return;
         }
-        if (this.overlayService.isCreated()) {
-            this.closePanel();
-        }
-        this.overlayService.setFocusDispatched(true);
-        if (!this.overlayService.isOpen()) {
-            this.openPanel();
-        }
+
+        this.closePanel();
+        this.openPanel();
     }
 
     private enabled = false;
@@ -142,9 +147,7 @@ export class SystelabVirtualKeyboardDirective implements OnInit, AfterViewInit, 
             const keyboardIcon = this.elementRef.nativeElement.parentElement.querySelector('i');
             keyboardIcon.removeEventListener('click', this.togglePanel.bind(this));
         }
-        if (this.overlayService.isCreated()) {
-            this.overlayService.destroy();
-        }
+        this.overlayService.destroy();
     }
 
     private togglePanel(): void {


### PR DESCRIPTION
# PR Details

## Description

* Shown virtual keyboard only when touching an input field by default
* Added a configuration option to allow showing virtual keyboard upon a mouse click
* Updated showcase and WDIO test scenarios to work with "taps" (instead of clicks) and to consider the new option

## Related Issue

https://github.com/systelab/systelab-virtual-keyboard/issues/9

## Motivation and Context

When working with a mouse and a keyboard, virtual keyboard is not desired to appear (as it is preferred to use the physical device which is more comfortable). This way, applications that work on both modes (touch & no-touch) can be optimized.

## How Has This Been Tested

* By adding a new input field in showcase that uses the new configuration option
* By updating the automated WDIO test suite

## Types of changes

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [x] I have read the **CONTRIBUTING** document
- [x] My code follows the code style of this project
- [x] My change requires a change to the documentation 
- [x] I have updated the documentation accordingly (README.md for each UI component)
- [x] I have added tests to cover my changes (at least 1 spec for each UI component with the same coverage as the master branch)
- [x] All new and existing tests passed
- [ ] A new branch needs to be created from master to evolve previous versions
- [x] Increase version in package.json following [Semantic Versioning](https://semver.org/)
- [x] All UI components must be added into the showcase (at least 1 component with the default settings)
- [x] Add the issue into the right [project](https://github.com/systelab/systelab-components/projects) with the proper status (In progress)
