### PR TITLE
Use specific classes to avoid use same default classes of CDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
                 "@wdio/local-runner": "7.16.10",
                 "@wdio/spec-reporter": "7.16.9",
                 "@wdio/types": "7.16.3",
-                "chromedriver": "124.0.1",
+                "chromedriver": "126.0.4",
                 "colors": "1.4.0",
                 "concurrently": "8.2.2",
                 "eslint": "8.56.0",
@@ -7888,9 +7888,9 @@
             }
         },
         "node_modules/chromedriver": {
-            "version": "124.0.1",
-            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-124.0.1.tgz",
-            "integrity": "sha512-hxd1tpAUhgMFBZd1h3W7KyMckxofOYCuKAMtcvBDAU0YKKorZcWuq6zP06+Ph0Z1ynPjtgAj0hP9VphCwesjZw==",
+            "version": "126.0.4",
+            "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-126.0.4.tgz",
+            "integrity": "sha512-mIdJqdocfN/y9fl5BymIzM9WQLy64x078i5tS1jGFzbFAwXwXrj3zmA86Wf3R/hywPYpWqwXxFGBJHgqZTuGCA==",
             "dev": true,
             "hasInstallScript": true,
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "@wdio/local-runner": "7.16.10",
         "@wdio/spec-reporter": "7.16.9",
         "@wdio/types": "7.16.3",
-        "chromedriver": "124.0.1",
+        "chromedriver": "126.0.4",
         "colors": "1.4.0",
         "concurrently": "8.2.2",
         "eslint": "8.56.0",

--- a/projects/showcase/src/styles.scss
+++ b/projects/showcase/src/styles.scss
@@ -3,12 +3,16 @@
 @import 'simple-keyboard/build/css/index';
 @import '@angular/cdk/overlay-prebuilt.css';
 
-.cdk-overlay-dark-backdrop {
+:root {
+    --systelab-virtual-keyboard-font-family: Lato, HelveticaNeue-Light, Helvetica Neue Light, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+}
+
+.systelab-virtual-keyboard__backdrop {
     backdrop-filter: saturate(30%);
     transition: all .3s !important;
 }
 
-.cdk-overlay-pane {
+.systelab-virtual-keyboard__panel {
     background-color: var(--slab_background_primary);
     box-shadow: 0 0 30px rgba(0, 0, 0, .2);
     border-radius: 7px;

--- a/projects/showcase/src/styles.scss
+++ b/projects/showcase/src/styles.scss
@@ -63,7 +63,7 @@
     }
 }
 
-.virtual-keyboard-show-button {
+.systelab-virtual-keyboard__show-button {
     display: flex;
     align-items: center;
     justify-content: center;

--- a/projects/showcase/test/mapping/input-field.ts
+++ b/projects/showcase/test/mapping/input-field.ts
@@ -43,6 +43,6 @@ export class InputField extends Widget {
     }
 
     private getVirtualKeyboardIcon(): ElementFinder {
-        return this.elem.byCSS(".virtual-keyboard-show-button");
+        return this.elem.byCSS(".systelab-virtual-keyboard__show-button");
     }
 }

--- a/projects/showcase/test/mapping/showcase-page.ts
+++ b/projects/showcase/test/mapping/showcase-page.ts
@@ -6,38 +6,38 @@ export class ShowcasePage extends BasePage {
     private static instance: ShowcasePage;
 
     public static get(): ShowcasePage {
-      return this.instance ? this.instance : (this.instance = new ShowcasePage());
+        return this.instance ? this.instance : (this.instance = new ShowcasePage());
     }
-  
+
     constructor() {
-      super('app-root');
+        super('app-root');
     }
 
     public getAutoAlphanumericLayoutField(): InputField {
-      return new InputField(this.byId('auto-alphanumeric-layout-field'));
+        return new InputField(this.byId('auto-alphanumeric-layout-field'));
     }
 
     public getAutoNumericLayoutField(): InputField {
-      return new InputField(this.byId('auto-numeric-layout-field'));
+        return new InputField(this.byId('auto-numeric-layout-field'));
     }
 
     public getManualNumericLayoutField(): InputField {
-      return new InputField(this.byId('manual-numeric-layout-field'));
+        return new InputField(this.byId('manual-numeric-layout-field'));
     }
-    
+
     public getShowVirtualKeyboardIconField(): InputField {
-      return new InputField(this.byId('show-virtual-keyboard-icon-field'));
+        return new InputField(this.byId('show-virtual-keyboard-icon-field'));
     }
 
     public getShowOnMouseClickField(): InputField {
-      return new InputField(this.byId('show-on-mouse-click-field'));
+        return new InputField(this.byId('show-on-mouse-click-field'));
     }
 
     public getFixedBottomPositioningField(): InputField {
-      return new InputField(this.byId('fixed-bottom-positioning-field'));
+        return new InputField(this.byId('fixed-bottom-positioning-field'));
     }
 
     public async tapOnBackground(): Promise<void> {
-      await this.byCSS('h1').tap();
+        await this.byCSS('h1').tap();
     }
 }

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard-overlay.service.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard-overlay.service.ts
@@ -58,10 +58,11 @@ export class SystelabVirtualKeyboardOverlayService {
             hasBackdrop: false,
             scrollStrategy: this.overlay.scrollStrategies.reposition(),
             disposeOnNavigation: true,
+            backdropClass: 'systelab-virtual-keyboard__backdrop',
+            panelClass: 'systelab-virtual-keyboard__panel',
         });
-        this.overlayRef.addPanelClass('virtual-keyboard-overlay-pane');
         if (fixedBottom) {
-            this.overlayRef.addPanelClass('virtual-keyboard-fixed-bottom');
+            this.overlayRef.addPanelClass('systelab-virtual-keyboard__panel--fixed-bottom');
         }
 
         this.updatePositionStrategy(inputOrigin, fixedBottom);
@@ -96,7 +97,7 @@ export class SystelabVirtualKeyboardOverlayService {
             this.focusDispatched = false;
             return;
         }
-        console.log('Document clicked:', event);
+
         event.stopPropagation();
         const simpleKeyboardElement = document.querySelector('.simple-keyboard');
         const showKeyboardButtonClicked = (event.target as HTMLElement)?.classList.contains('virtual-keyboard-show-button');

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.component.scss
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.component.scss
@@ -3,5 +3,5 @@
 }
 
 .simple-keyboard.hg-theme-default.myTheme {
-    font-family: Lato, HelveticaNeue-Light, Helvetica Neue Light, Helvetica Neue, Helvetica, Arial, Lucida Grande, sans-serif;
+    font-family: var(--systelab-virtual-keyboard-font-family);
 }

--- a/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.directive.ts
+++ b/projects/systelab-virtual-keyboard/src/lib/systelab-virtual-keyboard.directive.ts
@@ -222,7 +222,7 @@ export class SystelabVirtualKeyboardDirective implements OnInit, AfterViewInit, 
             const child = this.document.createElement('i');
             child.classList.add('fa');
             child.classList.add('fa-keyboard');
-            child.classList.add('virtual-keyboard-show-button');
+            child.classList.add('systelab-virtual-keyboard__show-button');
             this.renderer.appendChild(this.elementRef.nativeElement.parentElement, child);
             this.showKeyboardButtonElement = child;
         }


### PR DESCRIPTION
# PR Details

Avoid of using default CDK classes for styling virtual keyboard

## Related Issue

#11 
